### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ fscreen.fullscreenEnabled === true / false;
 // replacement for: document.fullscreenEnabled
 // mapped to: document.vendorMappedFullscreenEnabled
 
-fscreen.fullscreenElement === null / DOM Element;
+fscreen.fullscreenElement === null|undefined / DOM Element;
 // null if not in fullscreen mode, or the DOM element that's in fullscreen mode
+// undefined instead of null in iOS
 // replacement for: document.fullscreenElement
 // mapped to: document.vendorMappedFullsceenElement
 // note that fscreen.fullscreenElement uses a getter to retrieve the element
@@ -83,7 +84,7 @@ if (fscreen.fullscreenEnabled) {
 }
 
 function handler() {
- if (fscreen.fullscreenElement !== null) {
+ if (fscreen.fullscreenElement !== null && fscreen.fullscreenElement !== undefined) {
    console.log('Entered fullscreen mode');
  } else {
    console.log('Exited fullscreen mode');

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ fscreen.fullscreenEnabled === true / false;
 
 fscreen.fullscreenElement === null|undefined / DOM Element;
 // null if not in fullscreen mode, or the DOM element that's in fullscreen mode
-// undefined instead of null in iOS
+// undefined if fullscreen is not supported by device
 // replacement for: document.fullscreenElement
 // mapped to: document.vendorMappedFullsceenElement
 // note that fscreen.fullscreenElement uses a getter to retrieve the element


### PR DESCRIPTION
Hello,

At least on one device `fscreen.fullscreenElement` could be `undefined` instead of `null`. Tested on iPhone SE iOS 13.5 Safari.

Just wasted half a day to discover that. Hope this helps someone. Cheers :)